### PR TITLE
Swagger

### DIFF
--- a/backend/api/v1/users/views.py
+++ b/backend/api/v1/users/views.py
@@ -23,7 +23,7 @@ class UsersViewSet(UserViewSet):
         Выбор сериализатора в зависимости от
         просмотра или создания пользователя.
         """
-        if self.request.method in SAFE_METHODS:
+        if self.request and self.request.method in SAFE_METHODS:
             return UsersSerializer
         return UsersCreateSerializer
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -23,6 +23,7 @@ DJANGO_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "drf_yasg",
 ]
 
 LOCAL_APPS = [

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,14 +1,45 @@
-from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include, path
+from django.contrib import admin
+from django.urls import include, path, re_path
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.v1.urls", namespace="api")),
 ]
 
+schema_view = get_schema_view(
+    openapi.Info(
+        title="API",
+        default_version="v1",
+        description="Документация для проекта Street Russia hackaton",
+        contact=openapi.Contact(email="admin@kittygram.ru"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
+urlpatterns += [
+    re_path(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    re_path(
+        r"^swagger/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    re_path(
+        r"^redoc/$",
+        schema_view.with_ui("redoc", cache_timeout=0),
+        name="schema-redoc",
+    ),
+]
+
 if settings.DEBUG:
-    urlpatterns += static(
-        settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
-    )
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/data/apps.py
+++ b/backend/data/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class DataConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'data'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "data"

--- a/backend/info/apps.py
+++ b/backend/info/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class InfoConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'info'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "info"

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -2,9 +2,9 @@ from datetime import date
 
 from core.constants import UserFieldsLength
 from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.validators import RegexValidator
 from django.db import models
-from django.contrib.auth.validators import UnicodeUsernameValidator
 
 from .choice_classes import RoleChoices
 from .validators import validate_username

--- a/backend/users/validators.py
+++ b/backend/users/validators.py
@@ -5,14 +5,12 @@ from django.core.exceptions import ValidationError
 
 def validate_username(username):
     """Проверяет, соответствует ли имя пользователя допустимому формату."""
-    if username == 'me':
-        raise ValidationError(
-            'Нельзя использовать "me" как имя пользователя.'
-        )
-    invalid_symbols = re.sub(r'[\w.@+-]+', '', username)
+    if username == "me":
+        raise ValidationError('Нельзя использовать "me" как имя пользователя.')
+    invalid_symbols = re.sub(r"[\w.@+-]+", "", username)
     if invalid_symbols:
         raise ValidationError(
-            f'Нельзя использовать символы '
+            f"Нельзя использовать символы "
             f'{"".join(set(invalid_symbols))} в имени пользователя.'
         )
     return username

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,14 @@ django_debug_toolbar==3.8.1
 djangorestframework==3.15.1
 djangorestframework-simplejwt==5.3.1
 djoser==2.2.2
+drf-yasg==1.21.7
 drf_base64==2.0
 Faker==12.0.1
 filelock==3.14.0
 flake8==5.0.4
 identify==2.5.36
 idna==3.7
+inflection==0.5.1
 iniconfig==2.0.0
 mccabe==0.7.0
 mixer==7.2.2
@@ -49,6 +51,8 @@ PyYAML==6.0.1
 qrcode==7.4.2
 requests==2.31.0
 requests-oauthlib==2.0.0
+ruamel.yaml==0.18.6
+ruamel.yaml.clib==0.2.8
 six==1.16.0
 social-auth-app-django==5.4.1
 social-auth-core==4.5.4
@@ -57,6 +61,8 @@ sqlparse==0.5.0
 tomli==2.0.1
 typing_extensions==4.12.0
 tzdata==2024.1
+uritemplate==4.1.1
 urllib3==2.2.1
 virtualenv==20.26.1
+watchdog==4.0.1
 yapf==0.32.0


### PR DESCRIPTION
- Настроил Swagger для проверки API
- В UsersViewSet подправил функцию """Выбор сериализатора в зависимости от просмотра или создания пользователя. """  добавил проверку на None для self.request. 
- Не получилось настроить файл schema.yaml со статическими данными при помощи модуля drf-yasg для передачи фронту. Выпадала ошибка: **could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:builtins.getattr' in "backend/schema.yaml", line 1992, column 22**.